### PR TITLE
Use buildx to build docker images 

### DIFF
--- a/{{cookiecutter.repository_name}}/.github/workflows/docker-image.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/docker-image.yml
@@ -25,7 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -45,5 +51,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }} , latest
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Make it possible to build images for mulitple platforms.
Current solution only works for amd64, but many are using arm64.