### PR TITLE
Add support for click as an alternative to argparse

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,7 +13,11 @@
     "pytest-cov",
     "none"
   ],
-  "use_argparse": "y",
+  "command_line_interface": [
+    "argparse",
+    "click",
+    "none"
+  ],
   "build_docs": "y",
   "docker": "y",
   "use_pre_commit": "y",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -28,7 +28,7 @@ REMOVE_PATHS = [
     "docker/Dockerfile",
     "docker",
     {% endif %}
-    {%- if cookiecutter.use_argparse|lower != "y" %}
+    {%- if cookiecutter.command_line_interface|lower == "none" %}
     'src/{{ cookiecutter.module_name }}/__main__.py',
     'src/{{ cookiecutter.module_name }}/cli.py',
     {% endif %}

--- a/{{cookiecutter.repository_name}}/pyproject.toml
+++ b/{{cookiecutter.repository_name}}/pyproject.toml
@@ -8,8 +8,13 @@ description = "{{cookiecutter.project_short_description}}"
 authors = [{name = "{{cookiecutter.full_name}}", email = "{{cookiecutter.email}}"}]
 license = {file = "LICENSE"}
 readme = "README.md"
+{% if cookiecutter.command_line_interface|lower == "click" -%}
+dependencies = [
+    'click'
+]
+{%- endif %}
 
-{% if cookiecutter.use_argparse|lower == "y" -%}
+{% if cookiecutter.command_line_interface|lower != "y" -%}
 [project.scripts]
 {{cookiecutter.module_name}} = "{{cookiecutter.module_name}}.cli:main"
 {%- endif %}

--- a/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__main__.py
+++ b/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/__main__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from {{cookiecutter.module_name}}.cli import main
-{% if cookiecutter.use_argparse|lower == 'y' -%}
+{% if cookiecutter.command_line_interface|lower != 'none' -%}
 if __name__ == "__main__":
     import sys
     sys.exit(main())

--- a/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/cli.py
+++ b/{{cookiecutter.repository_name}}/src/{{cookiecutter.module_name}}/cli.py
@@ -1,8 +1,6 @@
 """Console script for {{cookiecutter.module_name}}."""
-
+{%- if cookiecutter.command_line_interface|lower == 'argparse' %}
 import argparse
-{%- if cookiecutter.use_argparse|lower == 'y' %}
-
 
 def main():
     """Console script for {{cookiecutter.module_name}}."""
@@ -14,5 +12,17 @@ def main():
     print("Arguments: " + str(args._))
     print("Replace this message by putting your code into "
           "{{cookiecutter.module_name}}.cli.main")
+    return 0
+{%- elif cookiecutter.command_line_interface|lower == 'click' %}
+import click
+
+
+@click.command()
+@click.option("--count", default=1, help="Number of greetings.")
+@click.option("--name", prompt="Your name", help="The person to greet.")
+def main(count, name):
+    """Simple program that greets NAME for a total of COUNT times."""
+    for x in range(count):
+        click.echo(f"Hello {name}!")
     return 0
 {% endif -%} 


### PR DESCRIPTION
Adding the possibility to use click as command line interface, using the example from the click docs as the template: https://click.palletsprojects.com/en/8.1.x/

Address https://github.com/scientificcomputing/generate-python-package/issues/4