### PR TITLE
Only build toc files and add pytest_cache to exclude patterns

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ title: template-repo
 author: Jørgen S. Dokken
 logo: "logo.png"
 copyright: "2022"
+only_build_toc_files: true
 
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
@@ -31,4 +32,4 @@ sphinx:
   - 'sphinx.ext.napoleon'
   - 'sphinx.ext.viewcode'
 
-exclude_patterns: ["**cookiecutter.repository_name**"] 
+exclude_patterns: ["**cookiecutter.repository_name**", ".pytest_cache/*"] 

--- a/{{cookiecutter.repository_name}}/_config.yml
+++ b/{{cookiecutter.repository_name}}/_config.yml
@@ -5,6 +5,7 @@ title: {{ cookiecutter.project_name }}
 author: {{ cookiecutter.full_name }}
 logo: "docs/logo.png"
 copyright: "{% now 'utc', '%Y' %}"
+only_build_toc_files: true
 
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
@@ -32,4 +33,4 @@ sphinx:
   - 'sphinx.ext.napoleon'
   - 'sphinx.ext.viewcode'
 
-exclude_patterns: ["README.md",] 
+exclude_patterns: ["README.md",".pytest_cache/*"] 


### PR DESCRIPTION
When I try to build the book from the root directory, the default behaviour is to recursively traverse through all the subfolders an search for notebooks and markdown files. Since I usually create a virtual environment in this directory this is a problem because it will try to execute all notebook files inside the virtual environment. To change this behaviour I set
```yaml
only_build_toc_files: true
```
in `_config.yml` (both in this repo and in the generated repo).

Moreover, even though this flag is set to through it still tries to build the files in my `pytest_cache` folder (which appears after pytest has been run), and this folder contains markdown files as will. Therefore I am also adding this folder to the `exclude_patterns`